### PR TITLE
Fixes for deprecated properties and methods in 0.8.x

### DIFF
--- a/src/module/actor/sheets/CharacterSheet.ts
+++ b/src/module/actor/sheets/CharacterSheet.ts
@@ -78,7 +78,7 @@ export class CharacterSheet extends ActorSheet<ActorSheet.Data<FateActor>, FateA
     getData() {
         // Basic fields and flags
         let data: any = {
-            owner: this.actor.owner,
+            owner: this.actor.isOwner,
             options: this.options,
             editable: this.isEditable,
             isTemplateActor: this.actor.isTemplateActor,
@@ -119,7 +119,7 @@ export class CharacterSheet extends ActorSheet<ActorSheet.Data<FateActor>, FateA
         const buttons = super._getHeaderButtons();
 
         // Edit mode button to toggle which interactive elements are visible on the sheet.
-        const canConfigure = game.user?.isGM || this.actor.owner;
+        const canConfigure = game.user?.isGM || this.actor.isOwner;
         if (this.options.editable && canConfigure) {
             buttons.unshift(
                 {

--- a/src/module/actor/sheets/GroupSheet.ts
+++ b/src/module/actor/sheets/GroupSheet.ts
@@ -41,7 +41,7 @@ export class GroupSheet extends ActorSheet<ActorSheet.Data<FateActor>> {
     getData() {
         // Basic fields and flags
         const data: any = {
-            owner: this.actor.owner,
+            owner: this.actor.isOwner,
             options: this.options,
             editable: this.isEditable,
             isTemplateActor: this.actor.isTemplateActor,

--- a/src/module/components/Automation/Automation.ts
+++ b/src/module/components/Automation/Automation.ts
@@ -30,7 +30,7 @@ export class Automation extends BaseComponent {
     }
 
     static async getSheetData(sheetData, sheet) {
-        const skillReferences = this.getSkillReferences(sheet.entity).map((ref, index) => {
+        const skillReferences = this.getSkillReferences(sheet.document).map((ref, index) => {
             ref.index = index;
             return ref;
         });
@@ -38,7 +38,7 @@ export class Automation extends BaseComponent {
         sheetData.statusReferences = skillReferences.filter((ref) => ref.type === TYPES.STATUS || ref.type === undefined);
         sheetData.boxReferences = skillReferences.filter((ref) => ref.type === TYPES.BOXES);
 
-        sheetData.skillReferenceSettings = this.getSkillReferenceSettings(sheet.entity);
+        sheetData.skillReferenceSettings = this.getSkillReferenceSettings(sheet.document);
         sheetData.availableSkillLevels = this.getAvailableSkillLevels();
         sheetData.availableOperators = this.getAvailableOperators();
         sheetData.availableConjunctions = this.getAvailableConjunctions();
@@ -55,7 +55,7 @@ export class Automation extends BaseComponent {
     static async _onAddReference(e, sheet, type = TYPES.STATUS) {
         e.preventDefault();
 
-        const entity = sheet.entity;
+        const entity = sheet.document;
         await this.addSkillReference(entity, type);
     }
 
@@ -64,7 +64,7 @@ export class Automation extends BaseComponent {
 
         let value = e.currentTarget.value;
         const dataset = e.currentTarget.dataset;
-        const entity = sheet.entity;
+        const entity = sheet.document;
         const index = dataset.index;
         const field = dataset.field;
 
@@ -86,7 +86,7 @@ export class Automation extends BaseComponent {
 
         let value = e.currentTarget.value;
         const dataset = e.currentTarget.dataset;
-        const entity = sheet.entity;
+        const entity = sheet.document;
         const setting = dataset.setting;
 
         // Check for numbers as only strings are passed
@@ -106,7 +106,7 @@ export class Automation extends BaseComponent {
         e.preventDefault();
 
         const dataset = e.currentTarget.dataset;
-        const entity = sheet.entity;
+        const entity = sheet.document;
         const index = dataset.index;
 
         // Return early of no index was provided

--- a/src/module/components/Radio/Radio.ts
+++ b/src/module/components/Radio/Radio.ts
@@ -34,7 +34,7 @@ export class Radio extends BaseComponent {
 
         const dataset = event.currentTarget.dataset;
         const dataKey = dataset.name;
-        const sheetEntity = sheet.entity;
+        const sheetEntity = sheet.document;
 
         // Sane default
         let value: number | string = "";

--- a/src/module/item/BaseItem.ts
+++ b/src/module/item/BaseItem.ts
@@ -92,7 +92,7 @@ export abstract class BaseItem {
         e.stopPropagation();
 
         const data = e.currentTarget.dataset;
-        const item = sheet.actor.getOwnedItem(data.item);
+        const item = sheet.actor.items.get(data.item);
 
         if (item) {
             item.sheet.render(true);
@@ -107,7 +107,7 @@ export abstract class BaseItem {
         e.stopPropagation();
 
         const data = e.currentTarget.dataset;
-        const item = sheet.actor.getOwnedItem(data.item);
+        const item = sheet.actor.items.get(data.item);
 
         new Dialog(
             {
@@ -152,7 +152,7 @@ export abstract class BaseItem {
 
         // We have to reload the item for it to have a sheet
         // Todo: Fix to use renderSheet option on creation
-        const createdItem = sheet.actor.getOwnedItem(newItem._id);
+        const createdItem = sheet.actor.items.get(newItem._id);
         createdItem.sheet.render(true);
     }
 

--- a/src/module/item/BaseItem.ts
+++ b/src/module/item/BaseItem.ts
@@ -124,7 +124,7 @@ export abstract class BaseItem {
                         icon: '<i class="fas fa-check"></i>',
                         label: game.i18n.localize("FAx.Dialog.Confirm"),
                         callback: async () => {
-                            await sheet.actor.deleteOwnedItem(data.item);
+                            await item.delete();
                         },
                     },
                 },

--- a/src/module/item/aspect/AspectItem.ts
+++ b/src/module/item/aspect/AspectItem.ts
@@ -18,7 +18,7 @@ export class AspectItem extends BaseItem {
         e.preventDefault();
 
         const dataset = e.currentTarget.dataset;
-        const item = sheet.actor.getOwnedItem(dataset.itemId);
+        const item = sheet.actor.items.get(dataset.itemId);
         const input = $(e.currentTarget).html();
 
         // Check if the value of the input field changed

--- a/src/module/item/consequence/ConsequenceItem.ts
+++ b/src/module/item/consequence/ConsequenceItem.ts
@@ -38,7 +38,7 @@ export class ConsequenceItem extends BaseItem {
         e.preventDefault();
 
         const dataset = e.currentTarget.dataset;
-        const item = sheet.actor.getOwnedItem(dataset.item);
+        const item = sheet.actor.items.get(dataset.item);
 
         if (item) {
             item.update(
@@ -54,7 +54,7 @@ export class ConsequenceItem extends BaseItem {
         e.preventDefault();
 
         const dataset = e.currentTarget.dataset;
-        const item = sheet.actor.getOwnedItem(dataset.itemId);
+        const item = sheet.actor.items.get(dataset.itemId);
         const input = $(e.currentTarget).html();
 
         // Check if the value of the input field changed

--- a/src/module/item/skill/SkillItem.ts
+++ b/src/module/item/skill/SkillItem.ts
@@ -100,7 +100,10 @@ export class SkillItem extends BaseItem {
         const template = "systems/fatex/templates/chat/roll-skill.hbs";
         const rank = parseInt(skill.data.rank) || 0;
         const actor = sheet.actor;
-        const roll = new Roll("4dF").roll();
+        // The  League of Foundry Developers types are missing the new async parameter
+        // This will become async by default in 0.9.x
+        /* @ts-ignore */
+        const roll = new Roll("4dF").evaluate({ async: false });
         const dice = this.getDice(roll);
         const total = this.getTotalString((roll.total || 0) + rank);
         const ladder = this.getLadderLabel((roll.total || 0) + rank);

--- a/src/module/item/skill/SkillItem.ts
+++ b/src/module/item/skill/SkillItem.ts
@@ -109,7 +109,7 @@ export class SkillItem extends BaseItem {
         const templateData = { skill, rank, dice, total, ladder };
 
         const chatData = {
-            user: game.user?._id,
+            user: game.user?.id,
             speaker: ChatMessage.getSpeaker({ actor: actor }),
             type: CONST.CHAT_MESSAGE_TYPES.ROLL,
             sound: CONFIG.sounds.dice,

--- a/src/module/item/skill/SkillItem.ts
+++ b/src/module/item/skill/SkillItem.ts
@@ -59,7 +59,7 @@ export class SkillItem extends BaseItem {
         e.stopPropagation();
 
         const dataset = e.currentTarget.dataset;
-        const skill = sheet.actor.getOwnedItem(dataset.item);
+        const skill = sheet.actor.items.get(dataset.item);
 
         if (skill) {
             const rank = skill.data.data.rank;
@@ -88,7 +88,7 @@ export class SkillItem extends BaseItem {
         }
 
         const dataset = e.currentTarget.dataset;
-        const skill = sheet.actor.getOwnedItem(dataset.itemId);
+        const skill = sheet.actor.items.get(dataset.itemId);
 
         if (skill) {
             await this.rollSkill(sheet, skill);

--- a/src/module/item/stunt/StuntItem.ts
+++ b/src/module/item/stunt/StuntItem.ts
@@ -28,7 +28,7 @@ export class StuntItem extends BaseItem {
         e.preventDefault();
 
         const dataset = e.currentTarget.dataset;
-        const item = sheet.actor.getOwnedItem(dataset.item);
+        const item = sheet.actor.items.get(dataset.item);
 
         if (item) {
             await item.update(


### PR DESCRIPTION
I've updated several deprecated properties and methods that were triggering warnings in Foundry 0.8.x. There are still some deprecation warnings that I may get to later on, including several warnings when creating new items on sheets.

I've had to disable typing on line 106 of `SkillItem.ts`, as the League types are not up to date. I'm planning to submit a PR for their repo as well, but it could be a little while before that gets released.