### PR TITLE
Fixes issue #52 relating to the position of actor images

### DIFF
--- a/src/styles/components/artwork/artwork.scss
+++ b/src/styles/components/artwork/artwork.scss
@@ -11,7 +11,7 @@
     width: 100%;
     height: 200px;
     background-size: cover;
-    background-position: center center;
+    background-position: top center;
 
     @include cutoff(25px);
 }


### PR DESCRIPTION
Very small update taking care of issue #52. Instead of centring the images within the allotted space on the character sheet, we now ensure that the top of the image is always visible. This should help to ensure that character heads are not being cut off.

Instead of this:

![image](https://user-images.githubusercontent.com/33249712/120799229-6185da00-c536-11eb-89f6-80009a726837.png)

We get this:

![image](https://user-images.githubusercontent.com/33249712/120799311-782c3100-c536-11eb-9219-451b98c652b2.png)