### PR TITLE
Adds clickable stunts and stunt chat output

### DIFF
--- a/src/module/item/stunt/StuntItem.ts
+++ b/src/module/item/stunt/StuntItem.ts
@@ -17,13 +17,13 @@ export class StuntItem extends BaseItem {
     static activateActorSheetListeners(html, sheet) {
         super.activateActorSheetListeners(html, sheet);
 
-        html.find(".fatex__stunt .fatex__headline").click((e) => {
+        html.find(".fatex__stunt > .fatex__headline").off().click((e) => {
             if ($(e.target).is(".fatex__stunt__collapse--toggle")) {
                 e.preventDefault();
                 return;
             }
 
-            this._onActiveStunt.call(this, e, sheet)
+            this._onActiveStunt.call(this, e, sheet);
         });
 
         html.find(".fatex__item__collapse").click((e) => this._onCollapseToggle.call(this, e, sheet));

--- a/src/styles/components/chat/chat.scss
+++ b/src/styles/components/chat/chat.scss
@@ -51,3 +51,7 @@
     font-size: 12px;
     display: block;
 }
+
+.fatex__chat__text {
+    padding: 0 0.5rem;
+}

--- a/src/styles/components/stunt/stunt.scss
+++ b/src/styles/components/stunt/stunt.scss
@@ -9,6 +9,7 @@
     padding: $component-padding 0;
 
     .fatex__headline {
+        cursor: pointer;
         padding-right: $component-padding * 4;
     }
 

--- a/system/templates/chat/display-stunt.hbs
+++ b/system/templates/chat/display-stunt.hbs
@@ -5,5 +5,5 @@
         </div>
     </div>
 
-    <div>Lorem ipsum dolor, sit amet consectetur adipisicing elit. Magni, unde? Dolore voluptatibus nam tempore numquam incidunt in beatae ad, quisquam non, eligendi reiciendis, perspiciatis autem tenetur accusantium officia error sit.</div>
+    <div class="fatex__chat__text">{{{ stunt.data.description }}}</div>
 </div>

--- a/system/templates/chat/display-stunt.hbs
+++ b/system/templates/chat/display-stunt.hbs
@@ -1,0 +1,9 @@
+<div class="fatex__chat">
+    <div class="fatex__chat__headline__wrapper">
+        <div class="fatex__chat__headline fatex__headline fatex__headline--icon fatex__headline--center">
+            {{ stunt.name }}
+        </div>
+    </div>
+
+    <div>Lorem ipsum dolor, sit amet consectetur adipisicing elit. Magni, unde? Dolore voluptatibus nam tempore numquam incidunt in beatae ad, quisquam non, eligendi reiciendis, perspiciatis autem tenetur accusantium officia error sit.</div>
+</div>


### PR DESCRIPTION
This PR partially handles a fairly old feature request (#39), giving users the ability to click stunts to send the stunt name and description to the chat.

New templates and styles have been added as part of the update.

I haven't touched aspects and consequences as part of this addition as the layout is completely different, and I think some thought needs to be put into how to best handle the additional functionality for those components.

I was originally going to merge this code into your existing `rollable-stunts` branch, but I see that that branch is way behind the current master. I've also been working with the 0.8.x version of FateX, so it might be best to roll this update into some of the 0.8 compatibility improvements and fixes. Feel free to merge it wherever you think is appropriate.