### PR TITLE
0.12.2 fixes

### DIFF
--- a/src/module/applications/template-actors/TemplateActorPicker.ts
+++ b/src/module/applications/template-actors/TemplateActorPicker.ts
@@ -19,8 +19,8 @@ export class TemplateActorPicker extends TemplateActorSettings {
     activateListeners(html) {
         super.activateListeners(html);
 
-        html.find(".fatex__template__choose").click((e) => this._chooseTemplate.call(this, e));
-        html.find(".fatex__template__empty").click((e) => this._emptyTemplate.call(this, e));
+        html.find(".fatex-eb-choose-template").click((e) => this._chooseTemplate.call(this, e));
+        html.find(".fatex-eb-empty-template").click((e) => this._emptyTemplate.call(this, e));
         html.find(".fatex__template__header__settings").click(() => this._openSettings.call(this));
     }
 

--- a/src/styles/components/apps/templates/templates.scss
+++ b/src/styles/components/apps/templates/templates.scss
@@ -94,3 +94,11 @@
         }
     }
 }
+
+.fatex__template__choose {
+    display: flex;
+    align-items: center;
+    gap: 1ch;
+    margin-left: 10px;
+    cursor: pointer;
+}

--- a/src/styles/components/apps/templates/templates.scss
+++ b/src/styles/components/apps/templates/templates.scss
@@ -94,11 +94,3 @@
         }
     }
 }
-
-.fatex__template__choose {
-    display: flex;
-    align-items: center;
-    gap: 1ch;
-    margin-left: 10px;
-    cursor: pointer;
-}

--- a/system/templates/apps/template-actors-picker.hbs
+++ b/system/templates/apps/template-actors-picker.hbs
@@ -15,7 +15,7 @@
 
     <div class="fatex__template">
         <header class="fatex-headline">
-            <h3 class="fatex-healing__text">{{localize "FAx.Template.Picker.Empty"}}</h3>
+            <h3 class="fatex-headline__text">{{localize "FAx.Template.Picker.Empty"}}</h3>
         </header>
 
         <style>
@@ -54,7 +54,7 @@
     {{#each templateActors as |template templateIndex|}}
         <div class="fatex__template">
             <div class="fatex-headline">
-                <span>{{ template.name }}</span>
+                <h3 class="fatex-headline__text">{{ template.name }}</h3>
             </div>
 
             <style>

--- a/system/templates/apps/template-actors-picker.hbs
+++ b/system/templates/apps/template-actors-picker.hbs
@@ -81,9 +81,10 @@
             </div>
 
             <div class="fatex__template__actions">
-                <span class="fatex__template__choose fa fa-file-medical" data-template="{{template._id}}">
-                    {{localize "FAx.Global.Actions.Choose"}}
-                </span>
+                <div class="fatex__template__choose" data-template="{{template._id}}">
+                    <i class="fa fa-file-medical"></i>
+                    <span>{{localize "FAx.Global.Actions.Choose"}}</span>
+                </div>
             </div>
         </div>
     {{else}}

--- a/system/templates/apps/template-actors-picker.hbs
+++ b/system/templates/apps/template-actors-picker.hbs
@@ -41,8 +41,9 @@
         </div>
 
         <div class="fatex__template__actions">
-                <span class="fatex__template__empty fatex__item__add">
-                    {{localize "FAx.Global.Actions.Create"}}
+                <span class="fatex-eb-empty-template fatex-button fatex-button--dark">
+                    <i class="fa fa-plus"></i>
+                    <span>{{localize "FAx.Global.Actions.Create"}}</span>
                 </span>
         </div>
     </div>
@@ -81,7 +82,10 @@
             </div>
 
             <div class="fatex__template__actions">
-                <div class="fatex__template__choose" data-template="{{template._id}}">
+                <div
+                    class="fatex-eb-choose-template fatex-button fatex-button--dark"
+                    data-template="{{template._id}}"
+                >
                     <i class="fa fa-file-medical"></i>
                     <span>{{localize "FAx.Global.Actions.Choose"}}</span>
                 </div>


### PR DESCRIPTION
Fixes a number of issues with the template picker page.

- Restores the buttons for selecting templates or a new empty actor
- Adds binding classes for those buttons
- Adds a missing icon for the "Create empty actor" button
- Corrects a font issue in the buttons caused by a template error
- Fixes the headlines for these templates, which were missing a class, leading to a minor visual bug