### PR TITLE
fixed broken french translation + some corrections + condensed stress box automation

### DIFF
--- a/system/data/fr/systems.json
+++ b/system/data/fr/systems.json
@@ -1,1 +1,1 @@
-["core", "accéléré", "condensé"]
+["core", "accelerated", "condensed"]

--- a/system/data/fr/systems/condensed.json
+++ b/system/data/fr/systems/condensed.json
@@ -1,6 +1,6 @@
 {
     "name": "Condensé",
-    "identifier": "condensé",
+    "identifier": "condensed",
     "types": {
         "Aspects": [
             {
@@ -21,16 +21,25 @@
                         }
                     },
                     {
-                        "name": "Nouvel Aspect",
-                        "type": "aspect"
+                        "name": "Relation",
+                        "type": "aspect",
+                        "data": {
+                            "label": "Relation"
+                        }
                     },
                     {
-                        "name": "Nouvel Aspect",
-                        "type": "aspect"
+                        "name": "Autre aspect",
+                        "type": "aspect",
+                        "data": {
+                            "label": "Autre aspect"
+                        }
                     },
                     {
-                        "name": "Nouvel Aspect",
-                        "type": "aspect"
+                        "name": "Autre aspect",
+                        "type": "aspect",
+                        "data": {
+                            "label": "Autre aspect"
+                        }
                     }
                 ]
             },
@@ -38,18 +47,15 @@
                 "label": "Option",
                 "entries": [
                     {
-                        "name": "Parenté",
+                        "name": "Relation",
                         "type": "aspect",
                         "data": {
-                            "label": "Parenté"
+                            "label": "Relation"
                         }
                     },
                     {
                         "name": "Autre aspect",
-                        "type": "aspect",
-                        "data": {
-                            "label": "Autre"
-                        }
+                        "type": "aspect"
                     }
                 ]
             }
@@ -58,7 +64,7 @@
             {
                 "entries": [
                     {
-                        "name": "Conséquence Légère",
+                        "name": "Conséquence légère",
                         "type": "consequence",
                         "data": {
                             "label": "Légère",
@@ -79,13 +85,13 @@
                                 },
                                 "skillReferences": [
                                     {
-                                        "skill": "Physique",
-                                        "condition": 4,
+                                        "skill": "Vigueur",
+                                        "condition": 5,
                                         "operator": 4
                                     },
                                     {
                                         "skill": "Volonté",
-                                        "condition": 4,
+                                        "condition": 5,
                                         "operator": 4
                                     }
                                 ]
@@ -93,7 +99,7 @@
                         }
                     },
                     {
-                        "name": "Conséquence Modérée",
+                        "name": "Conséquence modérée",
                         "type": "consequence",
                         "data": {
                             "label": "Modérée",
@@ -101,7 +107,7 @@
                         }
                     },
                     {
-                        "name": "Consequence Grave",
+                        "name": "Conséquence grave",
                         "type": "consequence",
                         "data": {
                             "label": "Grave",
@@ -119,126 +125,133 @@
                         "name": "Athlétisme",
                         "type": "skill",
                         "data": {
-                            "description": "Représente votre niveau d'aptitude physique. Les prouesses d'Athlétisme se concentre sur les déplacements, sauts, obstacles et l'esquive d'attaques."
+                            "description": "La mesure du potentiel physique. Les prouesses d’athlétisme se concentrent sur le déplacement comme la course, le saut ou l’escalade, et l’esquive."
+                        }
+                    },
+                    {
+                        "name": "Bricolage",
+                        "type": "skill",
+                        "data": {
+                            "description": "La capacité à créer ou détruire un mécanisme, fabriquer des trucs, et faire preuve d’une ingéniosité digne de MacGyver. Les prouesses de Bricolage vous permettent d’avoir le bon gadget à portée, un avantage pour construire ou détruire des choses, ou justifier l’utilisation de Bricolage à la place de Cambriolage ou Éducation sous certaines conditions."
                         }
                     },
                     {
                         "name": "Cambriolage",
                         "type": "skill",
                         "data": {
-                            "description": "Couvre les aptitudes à voler et entrer par effraction dans les endroits interdits. Les prouesses de Cambriolage accordent des bonus aux différents actes criminels, de la planification à l'évasion."
+                            "description": "La connaissance et le savoir-faire pour contourner les sécurités, faire du vol à la tire, ou plus généralement commettre des crimes. Les prouesses de Cambriolage donnent des avantages aux différentes étapes d’une action criminelle, de la préméditation au passage à l’acte et à la fuite."
                         }
                     },
                     {
                         "name": "Combat",
                         "type": "skill",
                         "data": {
-                            "description": "Couvre toutes les formes de combat au contact, aussi bien avec que sans armes. Les prouesses de combat inclut des armes et techniques particulières."
+                            "description": "La capacité à se battre au corps-à-corps, que ce soit avec des armes ou avec les poings. Les prouesses de Combat comprennent des armes de prédilection ou des techniques spéciales."
                         }
                     },
                     {
                         "name": "Conduite",
                         "type": "skill",
                         "data": {
-                            "description": "Diriger des véhicules lors de circonstances éreintantes, effectuer des manœuvres périlleuses, et plus simplement tirer le meilleur de votre monture. Les prouesses de Conduite peuvent être des manœuvres particulières, votre véhicule spéciale, ou la capacité à utiliser Conduite à la place d'une autre compétence tel que Cambriolage ou Académique dans certaines circonstances."
-                        }
-                    },
-                    {
-                        "name": "Combat à distance",
-                        "type": "skill",
-                        "data": {
-                            "description": "Toutes les pratiques de combat à distance, que cela soit les armes à feu, les couteaux de lancer, ou les arcs et flèches. Les prouesses de Combat à distance permettent de viser, de dégainer rapidement, ou d'avoir toujours une arme à portée de main."
+                            "description": "Le contrôle des véhicules dans les conditions les plus tendues, l’exécution de manœuvres risquées, ou simplement la capacité à tirer le meilleur de votre monture. Les prouesses de Conduite peuvent être des manœuvres personnelles, votre véhicule aux propriétés uniques, ou la capacité d’utiliser Conduite à la place de Cambriolage ou Éducation sous certaines conditions."
                         }
                     },
                     {
                         "name": "Discrétion",
                         "type": "skill",
                         "data": {
-                            "description": "Éviter de se faire repérer quand vous avez besoin de vous cacher. Les prouesses de Discrétion vous permettent de disparaître au vu et au su de tous, de vous mélanger à la foule, ou de vous déplacer dans les ombres discrètement."
+                            "description": "L’art de rester caché ou de fuir sans être découvert. Les prouesses de Discrétion peuvent vous permettre de disparaître à la vue de tous, de vous mêler à la foule, ou de progresser invisible parmi les ombres."
+                        }
+                    },
+                    {
+                        "name": "Éducation",
+                        "type": "skill",
+                        "data": {
+                            "description": "Les connaissances générales ou étudiées accessibles à tous, comme l’histoire, les sciences ou la médecine. Les prouesses d’Éducation font généralement référence à un domaine de connaissance spécialisé ou des compétences médicales."
                         }
                     },
                     {
                         "name": "Empathie",
                         "type": "skill",
                         "data": {
-                            "description": "Connaître et remarquer les changements d'humeur d'une personne. Les prouesses d'Empathie vous permettent d'évaluer une foule, détecter les mensonges ou aider une personne à récupérer une conséquence mentale."
+                            "description": "La faculté de juger de l’humeur ou des intentions d’autrui. Les prouesses d’Empathie peuvent être la possibilité d’estimer les réactions d’une foule, déceler les mensonges, ou aider quelqu’un à récupérer de ses conséquences mentales."
                         }
                     },
                     {
                         "name": "Enquête",
                         "type": "skill",
                         "data": {
-                            "description": "Recherches consciencieuses et réfléchies ainsi que la résolution de d'énigmes. S'utilise pour trouver des indices ou reconstituer la scène d'un crime. Les prouesses d'Enquête améliorent votre capacité de déduction et votre recherche d'informations."
+                            "description": "Réfléchir, étudier avec soin et lever le voile sur des mystères. Utilisez cette compétence pour reconstituer une scène de crime à partir d’indices. Les prouesses d’Enquête vous aident à tirer des conclusions brillantes ou à faire le lien entre tous les indices plus rapidement."
                         }
                     },
                     {
                         "name": "Érudition",
                         "type": "skill",
                         "data": {
-                            "description": "Connaissances spécialisées, arcaniques, qui étends les études Académiques, comprenant un thème surnaturel quelconque. Lorsque l'étrange se produit. Les prouesses d'Érudition sont souvent des applications pratiques de connaissances arcaniques, tel que le lancement de sorts. Certain cadre de campagne peuvent remplacer l'Érudition par une compétence différente, ou la combiner avec Académie."
+                            "description": "Connaissances occultes spécialisées qui sont hors du domaine de l’Éducation, sur des sujets qui sont d’une manière ou d’une autre surnaturels. On touche là aux choses de l’étrange. Les prouesses d’Érudition incluent souvent l’application pratique des connaissances occultes comme lancer des sorts. Certains cadres de jeu peuvent supprimer Érudition ou la remplacer par une autre compétence, ou l’inclure dans Éducation."
                         }
                     },
                     {
                         "name": "Intimidation",
                         "type": "skill",
                         "data": {
-                            "description": "Mettre en colère et instiller des émotions négatives. Grossière et manipulatrice, vous fera passer pour 'gros con'. Les prouesses d'Intimidation poussent vos adversaires à effectuer des actions idiotes, attirer leur attention sur vous, ou effrayer vos ennemis (si ceux-ci peuvent ressentir la peur)."
-                        }
-                    },
-                    {
-                        "name": "Métiers",
-                        "type": "skill",
-                        "data": {
-                            "description": "Utiliser pour réparer ou détruire des machines, bidouiller un truc, ou sortir de son chapeau une idée de génie à la MacGyver. Les prouesses de Métiers vous permettent d'avoir le gadget adéquate, de gagner un bonus pour construire ou casser des trucs, et si vous fournissez une explication peut remplacer les compétences Cambriolage ou Académie sous certaines circonstances."
+                            "description": "La capacité à pousser quelqu’un à agir comme vous le voulez. C’est une interaction grossière et manipulatrice, pas vraiment bienveillante. Les prouesses d'Intimidation peuvent vous permettre de pousser vos opposants à commettre des actions téméraires, devenir la cible des agresseurs, ou effrayer vos ennemis (à supposer qu’ils puissent ressentir la peur)."
                         }
                     },
                     {
                         "name": "Observation",
                         "type": "skill",
                         "data": {
-                            "description": "Remarquer des choses, repérer les ennuis avant qu'ils ne surviennent, et tout simplement être perceptif. C'est le complément de la compétence Enquête, qui est plus minutieuse et lente. Les prouesses d'Observation améliorent vos sens, vos temps de réaction, et vous rendent plus difficile à surprendre."
-                        }
-                    },
-                    {
-                        "name": "Physique",
-                        "type": "skill",
-                        "data": {
-                            "description": "Représente la force brute et l'endurance. Les prouesses Physique vous permettent de réaliser des exploits de force, de lutte, et annuler certaines conséquences physiques. De plus, un rang de Physique élevé vous accorde des cases de stress et des conséquences physiques supplémentaires."
+                            "description": "La capacité à relever un détail sur le moment, voir les ennuis arriver, ou plus généralement faire preuve de perspicacité. Cette compétence se démarque d'Enquête, qui est plus adaptée à une étude lente et réfléchie sur une situation. Les prouesses d’Observation affûtent vos sens, améliorent vos temps de réaction, ou vous aident à repérer ceux qui essayent de se cacher."
                         }
                     },
                     {
                         "name": "Relations",
                         "type": "skill",
                         "data": {
-                            "description": "Connaître la bonne personne et créer des liens qui peuvent vous aider. Les prouesses de Relations vous accordent des alliés disponibles et un réseau d'informations où que vous soyez dans le monde."
+                            "description": "La connaissance de la bonne personne ou des contacts qui peuvent vous aider. Les prouesses de Relations vous apportent des alliés prêts à vous aider et un réseau d’information partout où vous allez."
                         }
                     },
                     {
-                        "name": "Resources",
+                        "name": "Ressources",
                         "type": "skill",
                         "data": {
-                            "description": "Représent les biens matériels ainsi que la capacité à s'en servir. Ce n'est pas toujours sous forme d'argent. Cela peut refléter votre capacité à emprunter à des amis ou à piocher dans l'armurerie d'une organisation. Les prouesses de Ressources vous permettent d'utiliser Ressources à la place de Relations ou de Sociabilité ou d'avoir une invocation gratuite supplémentaire du moment que cela rapporte à court terme."
+                            "description": "L’accès à des ressources matérielles, pas seulement l’argent ou les biens personnels. Ça peut refléter la possibilité de faire un emprunt auprès d’un ami ou se servir dans l’armurerie d’une organisation. Les prouesses de Ressources vous permettent d’utiliser Ressources à la place de Relations ou Sociabilité, ou vous donner une invocation gratuite supplémentaire quand vous payez pour obtenir ce que vous voulez."
                         }
                     },
                     {
                         "name": "Sociabilité",
                         "type": "skill",
                         "data": {
-                            "description": "Faire bonne impression, susciter des émotions positives. Là où Intimidation est manipulateur, Sociabilité est sincérité, confiance, et bonne volonté. Les prouesses de Sociabilité vous permettent de lever la foule, d'améliorer votre relationnel, ou de créer des contacts."
+                            "description": "Créer des liens avec les autres ou travailler en équipe. Là où Intimidation est manipulation, Sociabilité est sincérité, confiance et bonne volonté. Les prouesses de Sociabilité vous permettent d’influencer une foule, d’améliorer des relations, ou de créer des liens."
+                        }
+                    },
+                    {
+                        "name": "Tir",
+                        "type": "skill",
+                        "data": {
+                            "description": "Toutes les formes de combat à distance, avec des armes, des couteaux de lancer, ou un arc et des flèches. Les prouesses de Tir vous permettent de faire des tirs ciblés, de dégainer rapidement, ou de toujours avoir un pistolet à portée."
                         }
                     },
                     {
                         "name": "Tromperie",
                         "type": "skill",
                         "data": {
-                            "description": "Permet de mentir et de tromper les gens. Les prouesses de Tromperie améliore la crédibilité de vos mensonges ou invente de fausses identités."
+                            "description": "La faculté de tricher et mentir de manière convaincante et avec aplomb. Les prouesses de Tromperie peuvent vous permettre de faire avaler un mensonge particulièrement grossier ou vous aider à créer des fausses identités."
+                        }
+                    },
+                    {
+                        "name": "Vigueur",
+                        "type": "skill",
+                        "data": {
+                            "description": "Résistance et puissance brute. Les prouesses de Vigueur vous permettent d’accomplir des efforts surhumains, de rouler des mécaniques en pleine mêlée, ou d’endurer des conséquences physiques. De plus, une Vigueur élevée vous octroie des cases de stress et des emplacements de conséquences physiques supplémentaires."
                         }
                     },
                     {
                         "name": "Volonté",
                         "type": "skill",
                         "data": {
-                            "description": "Représente la force mentale, votre capacité à surmonter les tentatives de séductions ou éviter les traumatismes. Les prouesses de Volonté vous permettent d'ignorer les conséquences mentales, supporter les douleurs mentales liées aux pouvoirs étranges, et à rester calme face aux intimidations. De plus, un rang de Volonté élevé vous accorde des cases de stress et des conséquences mentales supplémentaires."
+                            "description": "Force mentale, la faculté de résister à la tentation ou de surmonter un traumatisme. Les prouesses de Volonté vous permettent d’ignorer des conséquences mentales, d’endurer les assauts mentaux d’étranges pouvoirs, ou de garder contenance devant des ennemis qui tentent de vous intimider. De plus, une Volonté élevée vous octroie des cases de stress et des emplacements de conséquences mentales supplémentaires."
                         }
                     }
                 ]
@@ -248,19 +261,59 @@
             {
                 "entries": [
                     {
-                        "name": "Stress Physique",
+                        "name": "Stress physique",
                         "type": "stress",
                         "data": {
-                            "size": 4,
-                            "labelType": 0
+                            "size": 3,
+                            "labelType": 1
+                        },
+                        "flags": {
+                            "fatex": {
+                                "skillReferences": [
+                                    {
+                                        "type": 1,
+                                        "skill": "Vigueur",
+                                        "condition": 1,
+                                        "operator": 4,
+                                        "argument": 1
+                                    },
+                                    {
+                                        "type": 1,
+                                        "skill": "Vigueur",
+                                        "condition": 3,
+                                        "operator": 4,
+                                        "argument": 2
+                                    }
+                                ]
+                            }
                         }
                     },
                     {
-                        "name": "Stress Mental",
+                        "name": "Stress mental",
                         "type": "stress",
                         "data": {
-                            "size": 4,
-                            "labelType": 0
+                            "size": 3,
+                            "labelType": 1
+                        },
+                        "flags": {
+                            "fatex": {
+                                "skillReferences": [
+                                    {
+                                        "type": 1,
+                                        "skill": "Volonté",
+                                        "condition": 1,
+                                        "operator": 4,
+                                        "argument": 1
+                                    },
+                                    {
+                                        "type": 1,
+                                        "skill": "Volonté",
+                                        "condition": 3,
+                                        "operator": 4,
+                                        "argument": 2
+                                    }
+                                ]
+                            }
                         }
                     }
                 ]

--- a/system/languages/fr.json
+++ b/system/languages/fr.json
@@ -7,16 +7,16 @@
                 "+8": "Légendaire",
                 "+7": "Épique",
                 "+6": "Fantastique",
-                "+5": "Superbe",
+                "+5": "Formidable",
                 "+4": "Excellente",
                 "+3": "Bonne",
                 "+2": "Passable",
                 "+1": "Moyenne",
                 "+0": "Médiocre",
-                "-1": "Mauvais",
+                "-1": "Mauvaise",
                 "-2": "Atroce",
                 "-3": "Catastrophique",
-                "-4": "Horrifiante"
+                "-4": "Épouvantable"
             },
             "Actions": {
                 "Configure": "Configurer",
@@ -48,11 +48,11 @@
                 "Bio": "Bio"
             },
             "Buttons": {
-                "EditMode": "Edition",
+                "EditMode": "Édition",
                 "SheetSetup": "Paramètres"
             },
             "Stress": {
-                "Add": "Ajouter une piste de stress"
+                "Add": "Ajouter une jauge de stress"
             },
             "Messages": {
                 "EmptyActor": "Il semblerait que votre personnage soit encore vide. Vous pouvez le modifier à l'aide du menu <strong>édition</strong> ou <strong>paramètres</strong>. Les boutons pour déclencher le mode édition ou paramètre se situent dans la barre de titre"
@@ -60,11 +60,11 @@
         },
         "Item": {
             "Stress": {
-                "Name": "Label de la piste de stress",
-                "EditItem": "Éditer la piste de stress",
+                "Name": "Label de la jauge de stress",
+                "EditItem": "Éditer la jauge de stress",
                 "Size": "Nombre de cases",
                 "Description": "Description",
-                "DescriptionHelp": "La description sera visible sur la piste de stress.",
+                "DescriptionHelp": "La description sera visible sur la jauge de stress.",
                 "Boxes": {
                     "Label": "Modèle du label des cases",
                     "Custom": "Label personnalisé des cases",
@@ -117,13 +117,14 @@
                 "Name": "Titre de l'Extra",
                 "EditItem": "Éditer un Extra",
                 "Description": "Description",
-                "DescriptionHelp": "Une description complète de cette extra",
+                "DescriptionHelp": "Une description complète de cet extra",
                 "ShortDescription": "Description succinte",
-                "ShortDescriptionHelp": "Une description succinte de cette extra"
+                "ShortDescriptionHelp": "Une description succinte de cet extra"
             },
             "Automation": {
                 "Headline": "Automatisation",
-                "Description": "Aucune condition liée à compétence n'est définie. Veuillez ajouter une ou plusieurs conditions liée à une compétence pour activer l'automatisation.",
+                "BoxesHeadline": "Automatisation des cases",
+                "Description": "Aucune condition liée à une compétence n'est définie. Veuillez ajouter une ou plusieurs conditions liée à une compétence pour activer l'automatisation.",
                 "AddSkillRef": "Ajouter une condition",
                 "DisableUntil": "Désactiver jusqu'à",
                 "MultipleConditions": "Activer l'automatisation si",
@@ -148,7 +149,7 @@
             "EntityDelete": "Effacer",
             "EntityDeleteText": "Voulez-vous vraiment effacer de manière <strong>permanente</strong> cette entité ?",
             "ActorClear": "Enlever ses éléments",
-            "ActorClearText": "Voulez-vous vraiment enlever de cette acteur tout ses éléments <strong>et leur contenu</strong> de manière <strong>permanente</strong> ?",
+            "ActorClearText": "Voulez-vous vraiment enlever de cet acteur tout ses éléments <strong>et leur contenu</strong> de manière <strong>permanente</strong> ?",
             "Confirm": "Confirmer",
             "Cancel": "Annuler"
         },
@@ -162,7 +163,7 @@
                         "Aspects": "Effacer les aspects",
                         "Consequences": "Effacer les conséquences",
                         "Skills": "Effacer les compétences",
-                        "Stress": "Effacer les pistes de stress",
+                        "Stress": "Effacer les jauges de stress",
                         "Everything": "Effacer tout"
                     },
                     "Setup": {


### PR DESCRIPTION
Hello,

French translation for predefined actor template items (accelerated and condensed) was broken. This patch fixes it.

I also corrected some mistakes and updated the condensed translation (I'm the french translator of _Fate Condensed_).

The condensed system includes automated stress boxes (example: 3 Physical stress boxes by default. 4 boxes with a Physique skill rank at +1 or +2. 6 boxes with a Physique skill rank at +5 or higher. Same with Mental stress and Will skill.)

I let the additional mild consequence as is, but it should be splitted : an additional mild physical consequence for a Physique skill rank at +5 or higher and an additional mild mental consequence for a Will skill rank at +5 or higher. I can do that if you wish.

Regards,

Maxime