### PR TITLE
Removed inline HTML from the code.

### DIFF
--- a/src/module/item/stunt/StuntItem.ts
+++ b/src/module/item/stunt/StuntItem.ts
@@ -28,6 +28,8 @@ export class StuntItem extends BaseItem {
         super.activateActorSheetListeners(html, sheet);
 
         html.find(".fatex-js-item-collapse").click((e) => this._onCollapseToggle.call(this, e, sheet));
+        //For some reason this event bindes twice. So .unbind is a workaround.
+        html.find(".fatex-js-send-to-chat").unbind().click((e) => this._send2chat.call(this, e, sheet));
     }
 
     /*************************
@@ -48,5 +50,21 @@ export class StuntItem extends BaseItem {
                 {},
             );
         }
+    }
+
+    static async _send2chat(e, sheet) : Promise<any> {
+        e.preventDefault();
+        e.stopPropagation();
+
+        const stunt = sheet.actor.items.get(e.currentTarget.dataset.item);
+        const content = await renderTemplate("systems/fatex/templates/chat/stunt.hbs", {stunt});
+        
+        const chatData = {
+            speaker: {"actor" : sheet.actor._id},
+            type: CONST.CHAT_MESSAGE_TYPES.IC,
+            content: content
+        };
+        
+        return await ChatMessage.create(chatData);
     }
 }

--- a/system/templates/actor/tabs/extras.hbs
+++ b/system/templates/actor/tabs/extras.hbs
@@ -12,6 +12,7 @@
                         <i class="fatex-js-item-sort fatex-actions__icon fa fa-sort"></i>
                         <i class="fatex-js-extra-settings fatex-actions__icon fa fa-cog" data-item="{{extra._id}}"></i>
                         <i class="fatex-js-extra-delete fatex-actions__icon fatex-u-delete fa fa-trash" data-item="{{extra._id}}"></i>
+                        <i class="fatex-js-send-to-chat fatex-actions__icon fatex-actions__icon--no-hide fa fa-comment" data-item="{{extra._id}}"></i>
                         <i class="fatex-js-item-collapse fatex-actions__icon fatex-actions__icon--no-hide fa fa-chevron-up{{#if extra.system.collapsed}} fatex-actions__icon--reverse{{/if}}" data-item="{{extra._id}}"></i>
                     </div>
                 </header>

--- a/system/templates/actor/tabs/stunts.hbs
+++ b/system/templates/actor/tabs/stunts.hbs
@@ -23,6 +23,7 @@
                         <i class="fatex-js-item-sort fatex-actions__icon fa fa-sort"></i>
                         <i class="fatex-js-stunt-settings fatex-actions__icon fa fa-cog" data-item="{{stunt._id}}"></i>
                         <i class="fatex-js-stunt-delete fatex-actions__icon fatex-u-delete fa fa-trash" data-item="{{stunt._id}}"></i>
+                        <i class="fatex-js-send-to-chat fatex-actions__icon fatex-actions__icon--no-hide fa fa-comment" data-item="{{stunt._id}}"></i>
                         <i class="fatex-js-item-collapse fatex-actions__icon fatex-actions__icon--no-hide fa fa-chevron-up{{#if stunt.system.collapsed}} fatex-actions__icon--reverse{{/if}}" data-item="{{stunt._id}}"></i>
                     </div>
                 </header>

--- a/system/templates/chat/stunt.hbs
+++ b/system/templates/chat/stunt.hbs
@@ -1,0 +1,15 @@
+<div class="fatex-rollWrapper">
+    <header class="fatex-headline">
+        <h3 class="fatex-headline__text">{{ stunt.name }}</h3>
+    </header>
+
+    <div>
+        <div >
+            {{ stunt.system.shortDescription }}
+        </div >
+
+        <div class="fatex-result">
+            {{{ stunt.system.description }}}
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
Hi! I cleaned out the inline HTML from the code and added Handlebars. It's reusing existing CSS classes.
Looks like this now:

![image](https://github.com/anvil-vtt/FateX/assets/137091674/6040227c-6fda-4dd6-952f-39cedc29ef4d)

Handlebar template makes use of {{{ do not escape this html }}} feature, because user is expected to use markdown in stunt descriptions.