### PR TITLE
v13 Compatibility

### DIFF
--- a/src/module/features/ChatActionsFeature.ts
+++ b/src/module/features/ChatActionsFeature.ts
@@ -43,7 +43,7 @@ export class ChatActionsFeature {
     }
 
     static chatListeners(html) {
-        html.on("click", ".fatex-roll-actions button[data-action]", this._onChatCardAction.bind(this));
+        $(html).on("click", ".fatex-roll-actions button[data-action]", this._onChatCardAction.bind(this));
     }
 
     static async _onChatCardAction(event) {

--- a/system/system.json
+++ b/system/system.json
@@ -2,7 +2,7 @@
     "id": "fatex",
     "title": "FateX - Fate Extended",
     "description": "An extended implementation of Fate and its derivative systems",
-    "version": "1.4.5",
+    "version": "1.5.0",
     "authors": [
         {
             "name": "Patrick Bauer",
@@ -64,8 +64,8 @@
         }
     ],
     "compatibility": {
-        "minimum": "12",
-        "verified": "12"
+        "minimum": "13",
+        "verified": "13"
     },
     "socket": true,
     "url": "https://github.com/anvil-vtt/FateX",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,7 +10,7 @@ const glob = require("glob");
 const allTemplates = () => {
     return glob
         .sync("**/*.hbs", { cwd: path.join(__dirname, "system/templates") })
-        .map((file) => `"systems/fatex/templates/${file}"`)
+        .map((file) => `"systems/fatex/templates/${file.replace(/\\/g, "/")}"`) // Replace backslashes
         .join(", ");
 };
 


### PR DESCRIPTION
The only issue I found was the expectation that `html` in `chatListeners` was jQuery, but it is a regular HTML element in v13.

Otherwise, I updated the webpack.config.js per our discussion to fix the issue with `\t` in the path being treated as a tab.