### PR TITLE
Make rollSkill method await fateRoll.roll() for proper async call

### DIFF
--- a/src/module/item/skill/SkillItem.ts
+++ b/src/module/item/skill/SkillItem.ts
@@ -140,7 +140,7 @@ export class SkillItem extends BaseItem {
             return;
         }
 
-        fateRoll.roll();
+        await fateRoll.roll();
 
         const fateChatCard = FateChatCard.create(actor, [fateRoll]);
         await fateChatCard.sendToChat();


### PR DESCRIPTION
linked to [this issue](https://github.com/anvil-vtt/FateX/issues/146).


The rollSkill method was calling the asynchronous fateRoll.roll() function without awaiting its completion. This caused the chat card to be created and rendered before the dice results were calculated, leaving them blank. By adding the await keyword, we now ensure that the execution pauses until the roll is fully resolved, guaranteeing the dice data is populated before the chat message is sent.
