### PR TITLE
fix(groups): Resolve actor drag-and-drop

### DIFF
--- a/src/module/helper/ActorGroupHelper.ts
+++ b/src/module/helper/ActorGroupHelper.ts
@@ -19,7 +19,7 @@ export function getReferencesByGroupType(groupType: groupType = "manual", actor?
             return []; //getReferencesFromCurrentEncounter();
         default: {
             // @ts-ignore
-            const items = actor.items.filter((i) => ["actorReference", "tokenReference"].includes(i.type)).map((i) => i.data) as (ItemDataBaseProperties &
+            const items = actor.items.filter((i) => ["actorReference", "tokenReference"].includes(i.type)) as (ItemDataBaseProperties &
                 ReferenceItemData)[];
             return items.sort((a, b) => (a.sort || 0) - (b.sort || 0));
         }


### PR DESCRIPTION
linked to issue [145 ](url)https://github.com/anvil-vtt/FateX/issues/145

- Replaces deprecated `fromUuidSync` with the asynchronous `fromUuid`.
- Updates Item data creation to use the `system` property instead of the legacy `data` property.
- Corrects the logic for reading actor references to also use the `system` property.
- Replaces the deprecated global `TextEditor` call with its modern namespaced equivalent.