### PR TITLE
Feature/display aspect stunt extra to chat

### DIFF
--- a/src/module/actor/sheets/CharacterSheet.ts
+++ b/src/module/actor/sheets/CharacterSheet.ts
@@ -6,6 +6,7 @@ import { SheetSetup } from "../../applications/sheet-setup/SheetSetup";
 import { GroupSheet } from "./GroupSheet";
 import { ItemData } from "@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/data/data.mjs/itemData";
 import { DropData } from "@league-of-foundry-developers/foundry-vtt-types/src/foundry/client/data/abstract/client-document";
+import { BaseItem } from "../../item/BaseItem";
 
 export interface CharacterSheetOptions extends ActorSheet.Options {
     type?: string;
@@ -65,6 +66,10 @@ export class CharacterSheet extends ActorSheet<CharacterSheetOptions> {
         for (const sheetComponent in CONFIG.FateX.sheetComponents.actor) {
             CONFIG.FateX.sheetComponents.actor[sheetComponent].activateListeners(html, this);
         }
+
+        html.find('.fatex-js-item-to-chat').click((e) => {
+        BaseItem._onItemSendToChat(e, this);
+    });
     }
 
     /**
@@ -104,7 +109,7 @@ export class CharacterSheet extends ActorSheet<CharacterSheetOptions> {
         data.consequences = data.items.filter((item: ItemData) => item.type === "consequence");
 
         // @ts-ignore
-        data.enrichedBiography = await TextEditor.enrichHTML(this.object.system.biography.value, { async: true });
+        data.enrichedBiography = await foundry.applications.ux.TextEditor.implementation.enrichHTML(this.object.system.biography.value, { async: true });
 
         // Allow every item type to add data to the actorsheet
         for (const itemType in CONFIG.FateX.itemClasses) {

--- a/src/module/chat/FateChatCard.ts
+++ b/src/module/chat/FateChatCard.ts
@@ -56,6 +56,6 @@ export class FateChatCard extends FateChatCardDataModel {
         const template = "systems/fatex/templates/chat/chat-card.hbs";
         const rolls = await Promise.all(this.rolls.map((roll) => roll.render()));
 
-        return await renderTemplate(template, { rolls });
+        return await foundry.applications.handlebars.renderTemplate(template, { rolls });
     }
 }

--- a/src/module/chat/FateRoll.ts
+++ b/src/module/chat/FateRoll.ts
@@ -147,7 +147,7 @@ export class FateRoll extends FateRollDataModel {
     async render() {
         const template = "systems/fatex/templates/chat/roll.hbs";
 
-        return await renderTemplate(template, this);
+        return await foundry.applications.handlebars.renderTemplate(template, this);
     }
 
     static determineMagicCount(skill: SkillItemData & ItemDataProperties) {

--- a/src/module/item/BaseItem.ts
+++ b/src/module/item/BaseItem.ts
@@ -188,7 +188,7 @@ static async sendToChat(item: FateItem) {
     }
     
     // @ts-ignore
-    const enrichedDescription = await TextEditor.enrichHTML(descriptionSource, { async: true });
+    const enrichedDescription = await foundry.applications.ux.TextEditor.implementation.enrichHTML(descriptionSource, { async: true });
 
     const templateData = {
         item: {
@@ -201,7 +201,8 @@ static async sendToChat(item: FateItem) {
         speaker: ChatMessage.getSpeaker({ actor: item.actor ?? undefined }),
     };
 
-    const content = await renderTemplate("systems/fatex/templates/chat/item-card.hbs", templateData);
+    // @ts-ignore
+    const content = await foundry.applications.handlebars.renderTemplate("systems/fatex/templates/chat/item-card.hbs", templateData);
 
     await ChatMessage.create({
         speaker: templateData.speaker,

--- a/src/module/item/extra/ExtraItem.ts
+++ b/src/module/item/extra/ExtraItem.ts
@@ -10,7 +10,7 @@ export class ExtraItem extends StuntItem {
 
         for (const extra of sheetData.extras) {
             // @ts-ignore
-            extra.system.description = await TextEditor.enrichHTML(extra.system.description, { async: true });
+            extra.system.description = await foundry.applications.ux.TextEditor.implementation.enrichHTML(extra.system.description, { async: true });
         }
 
         return sheetData;
@@ -18,7 +18,7 @@ export class ExtraItem extends StuntItem {
 
     static async getSheetData(sheetData) {
         // @ts-ignore
-        sheetData.enrichedDescription = await TextEditor.enrichHTML(sheetData.system.description, { async: true });
+        sheetData.enrichedDescription = await foundry.applications.ux.TextEditor.implementation.enrichHTML(sheetData.system.description, { async: true });
     }
     
 }

--- a/src/module/item/stunt/StuntItem.ts
+++ b/src/module/item/stunt/StuntItem.ts
@@ -13,7 +13,7 @@ export class StuntItem extends BaseItem {
 
         for (const stunt of sheetData.stunts) {
             // @ts-ignore
-            stunt.system.description = await TextEditor.enrichHTML(stunt.system.description, { async: true });
+            stunt.system.description = await foundry.applications.ux.TextEditor.implementation.enrichHTML(stunt.system.description, { async: true });
         }
 
         return sheetData;
@@ -21,7 +21,7 @@ export class StuntItem extends BaseItem {
 
     static async getSheetData(sheetData) {
         // @ts-ignore
-        sheetData.enrichedDescription = await TextEditor.enrichHTML(sheetData.system.description, { async: true });
+        sheetData.enrichedDescription = await foundry.applications.ux.TextEditor.implementation.enrichHTML(sheetData.system.description, { async: true });
     }
 
     static activateActorSheetListeners(html, sheet) {

--- a/src/styles/abstract/mixins.scss
+++ b/src/styles/abstract/mixins.scss
@@ -30,3 +30,19 @@
     bottom: initial;
     right: initial;
 }
+
+@mixin fatex-rank-indicator($font-size: 24px) {
+    position: absolute;
+    top: 0;
+    left: 100%;
+    transform: translate(-25px, 0px);
+    font-weight: 900;
+    font-size: $font-size;
+    color: $sheet-background;
+    -webkit-text-stroke: 2px $fatex-primary-color;
+    text-shadow: initial;
+    
+    &--negative {
+        color: $caution-color;
+    }
+}

--- a/src/styles/abstract/mixins.scss
+++ b/src/styles/abstract/mixins.scss
@@ -3,7 +3,7 @@
     position: absolute;
     top: -1px;
     left: -1px;
-    border-top: $size solid $fatex-cutout-bg-color;
+    border-top: $size solid $sheet-background;
     border-right: $size solid transparent;
 }
 
@@ -12,7 +12,7 @@
     position: absolute;
     top: -1px;
     right: -1px;
-    border-top: $size solid $fatex-cutout-bg-color;
+    border-top: $size solid $sheet-background;
     border-left: $size solid transparent;
 }
 
@@ -21,7 +21,7 @@
     position: absolute;
     bottom: -1px;
     right: -1px;
-    border-bottom: $size solid $fatex-cutout-bg-color;
+    border-bottom: $size solid $sheet-background;
     border-left: $size solid transparent;
 }
 

--- a/src/styles/abstract/mixins.scss
+++ b/src/styles/abstract/mixins.scss
@@ -3,7 +3,7 @@
     position: absolute;
     top: -1px;
     left: -1px;
-    border-top: $size solid #f1f2f6;
+    border-top: $size solid $fatex-cutout-bg-color;
     border-right: $size solid transparent;
 }
 
@@ -12,7 +12,7 @@
     position: absolute;
     top: -1px;
     right: -1px;
-    border-top: $size solid #f1f2f6;
+    border-top: $size solid $fatex-cutout-bg-color;
     border-left: $size solid transparent;
 }
 
@@ -21,7 +21,7 @@
     position: absolute;
     bottom: -1px;
     right: -1px;
-    border-bottom: $size solid #f1f2f6;
+    border-bottom: $size solid $fatex-cutout-bg-color;
     border-left: $size solid transparent;
 }
 

--- a/src/styles/abstract/mixins.scss
+++ b/src/styles/abstract/mixins.scss
@@ -39,8 +39,15 @@
     font-weight: 900;
     font-size: $font-size;
     color: $sheet-background;
-    -webkit-text-stroke: 2px $fatex-primary-color;
-    text-shadow: initial;
+    text-shadow: 
+        -2px -2px 0 $fatex-primary-color,
+        2px -2px 0 $fatex-primary-color,
+        -2px 2px 0 $fatex-primary-color,
+        2px 2px 0 $fatex-primary-color,
+        -2px 0 0 $fatex-primary-color,
+        2px 0 0 $fatex-primary-color,
+        0 -2px 0 $fatex-primary-color,
+        0 2px 0 $fatex-primary-color;
     
     &--negative {
         color: $caution-color;

--- a/src/styles/abstract/variables.scss
+++ b/src/styles/abstract/variables.scss
@@ -5,7 +5,6 @@ $component-padding: 10px;
 $primary-color: rgba(47, 53, 66, 1);
 
 $sheet-background: rgb(241, 242, 246);
-$fatex-cutout-bg-color: var(--fatex-cutout-bg-color, #{$sheet-background});
 $message-background: transparentize($primary-color, 0.7);
 
 $primary-text-color: #191813;

--- a/src/styles/abstract/variables.scss
+++ b/src/styles/abstract/variables.scss
@@ -5,6 +5,7 @@ $component-padding: 10px;
 $primary-color: rgba(47, 53, 66, 1);
 
 $sheet-background: rgb(241, 242, 246);
+$fatex-cutout-bg-color: var(--fatex-cutout-bg-color, #{$sheet-background});
 $message-background: transparentize($primary-color, 0.7);
 
 $primary-text-color: #191813;

--- a/src/styles/base/foundry-ui.scss
+++ b/src/styles/base/foundry-ui.scss
@@ -3,15 +3,10 @@
 }
 
 .window-app .window-content,
-#chat-log .message,
 #chat-form textarea,
 #chat-controls div.roll-type-select select,
 .sidebar-tab .directory-header .header-search input,
 #chat-form .cm-s-easymde {
     background: $sheet-background;
     color: var(--fatex-primary-text-color, $primary-text-color);
-}
-
-#chat-log .message.whisper {
-    opacity: 0.8;
 }

--- a/src/styles/components/chat.scss
+++ b/src/styles/components/chat.scss
@@ -1,6 +1,9 @@
 .fatex-chat {
     font-size: 24px;
     text-align: center;
+    background: $sheet-background;
+    padding: 5px;
+    border-radius: 3px;
 }
 
 .fatex-chat__headline-container {

--- a/src/styles/components/chat.scss
+++ b/src/styles/components/chat.scss
@@ -45,6 +45,16 @@ li.chat-message {
     background: $sheet-background;
     padding: 5px;
     border-radius: 3px;
+    
+    .fatex-headline__icon {
+        -webkit-text-stroke: 3px black;
+        -webkit-text-fill-color: #ffffff;
+        paint-order: stroke fill;
+
+        &--negative {
+            -webkit-text-fill-color: $caution-color;
+        }
+    }
 }
 
 .fatex-chat__headline-container {

--- a/src/styles/components/chat.scss
+++ b/src/styles/components/chat.scss
@@ -48,13 +48,6 @@ li.chat-message {
     
     .fatex-headline__icon {
         @include fatex-rank-indicator(24px);
-        -webkit-text-stroke: 3px black;
-        -webkit-text-fill-color: $light-text-color;
-        paint-order: stroke fill;
-
-        &--negative {
-            -webkit-text-fill-color: $caution-color;
-        }
     }
 }
 

--- a/src/styles/components/chat.scss
+++ b/src/styles/components/chat.scss
@@ -47,6 +47,7 @@ li.chat-message {
     border-radius: 3px;
     
     .fatex-headline__icon {
+        @include fatex-rank-indicator(24px);
         -webkit-text-stroke: 3px black;
         -webkit-text-fill-color: $light-text-color;
         paint-order: stroke fill;

--- a/src/styles/components/chat.scss
+++ b/src/styles/components/chat.scss
@@ -1,3 +1,44 @@
+#chat-log,
+.chat-log,
+.chat-sidebar {
+    background: transparent !important;
+}
+
+.chat-message,
+li.chat-message {
+    background: $sheet-background !important;
+    border: 1px solid rgba(0, 0, 0, 0.1) !important;
+    border-radius: 5px !important;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1) !important;
+    margin: 10px 6px !important;
+    padding: 0 !important;
+    
+    &:first-child { margin-top: 6px !important; }
+    &:last-child { margin-bottom: 6px !important; }
+    
+    .message-header,
+    .message-content {
+        background: transparent !important;
+        border: none !important;
+    }
+    
+    &.whisper {
+        opacity: 0.8;
+        background: rgba($sheet-background, 0.95) !important;
+        border-color: rgba(128, 0, 128, 0.2) !important;
+        box-shadow: 0 1px 3px rgba(128, 0, 128, 0.1) !important;
+        
+        .message-header {
+            opacity: 0.9;
+        }
+    }
+}
+
+.chat-message::before,
+.chat-message::after {
+    display: none !important;
+}
+
 .fatex-chat {
     font-size: 24px;
     text-align: center;

--- a/src/styles/components/chat.scss
+++ b/src/styles/components/chat.scss
@@ -48,7 +48,7 @@ li.chat-message {
     
     .fatex-headline__icon {
         -webkit-text-stroke: 3px black;
-        -webkit-text-fill-color: #ffffff;
+        -webkit-text-fill-color: $light-text-color;
         paint-order: stroke fill;
 
         &--negative {

--- a/src/styles/components/chat/_item-card.scss
+++ b/src/styles/components/chat/_item-card.scss
@@ -1,0 +1,29 @@
+.fatex-item-card {
+    font-family: var(--fatex-primary-font, "Montserrat", sans-serif);
+    background: var(--sheet-background, rgb(241, 242, 246));
+    color: var(--fatex-primary-text-color, #191813);
+    padding: 5px;
+    border-radius: 3px;
+    border: 1px solid var(--fatex-primary-color, rgba(47, 53, 66, 1));
+
+    .fatex-headline {
+        margin-bottom: 8px;
+    }
+
+    &__content {
+        display: flex;
+        align-items: flex-start;
+        gap: 10px;
+        padding: 5px;
+        font-size: 14px;
+    }
+
+    &__description {
+        flex: 1;
+        min-width: 0;
+        p {
+            margin: 0;
+        }
+    }
+
+}

--- a/src/styles/components/headline.scss
+++ b/src/styles/components/headline.scss
@@ -60,7 +60,6 @@
             left: initial;
             right: 100%;
             font-size: 24px;
-            text-shadow: 1px 1px 1px $sheet-background;
             transform: translate(15px, -7px);
         }
 

--- a/src/styles/components/headline.scss
+++ b/src/styles/components/headline.scss
@@ -45,15 +45,8 @@
     }
 
     &__icon {
-        position: absolute;
-        top: 0;
-        left: 100%;
+        @include fatex-rank-indicator();
         z-index: 100;
-        transform: translate(-25px, 0px);
-        font-weight: 900;
-        color: $sheet-background;
-        -webkit-text-stroke: 2px $fatex-primary-color;
-        text-shadow: initial;
         white-space: nowrap;
 
         &--skill {
@@ -61,10 +54,6 @@
             right: 100%;
             font-size: 24px;
             transform: translate(15px, -7px);
-        }
-
-        &--negative {
-            color: $caution-color;
         }
     }
 

--- a/src/styles/components/headline.scss
+++ b/src/styles/components/headline.scss
@@ -88,6 +88,10 @@
     }
 }
 
+.fatex-headline--chat .fatex-headline__text {
+    color: $light-text-color;
+}
+
 .fatex-section-heading {
     display: block;
     position: relative;

--- a/src/styles/fatex.scss
+++ b/src/styles/fatex.scss
@@ -5,6 +5,7 @@
 @import "base/typography";
 
 @import "components/**/*.scss";
+@import "components/chat/item-card";
 
 @import "legacy/chat";
 

--- a/src/styles/legacy/chat.scss
+++ b/src/styles/legacy/chat.scss
@@ -27,19 +27,7 @@
 }
 
 .fatex__chat__headline__icon {
-    position: absolute;
-    top: 0;
-    left: 100%;
-    transform: translate(-25px, 0px);
-    font-weight: 900;
-    font-size: 24px;
-    color: $sheet-background;
-    -webkit-text-stroke: 2px $fatex-primary-color;
-    text-shadow: initial;
-}
-
-.fatex__chat__headline__icon--negative {
-    color: $caution-color;
+    @include fatex-rank-indicator(24px);
 }
 
 .fatex__chat__dice {

--- a/system/templates/actor/tabs/extras.hbs
+++ b/system/templates/actor/tabs/extras.hbs
@@ -10,6 +10,7 @@
 
                     <div class="fatex-actions fatex-actions--headline">
                         <i class="fatex-js-item-sort fatex-actions__icon fa fa-sort"></i>
+                        <i class="fatex-js-item-to-chat fatex-actions__icon fatex-actions__icon--no-hide fa fa-comment" data-item="{{extra._id}}"></i>
                         <i class="fatex-js-extra-settings fatex-actions__icon fa fa-cog" data-item="{{extra._id}}"></i>
                         <i class="fatex-js-extra-delete fatex-actions__icon fatex-u-delete fa fa-trash" data-item="{{extra._id}}"></i>
                         <i class="fatex-js-item-collapse fatex-actions__icon fatex-actions__icon--no-hide fa fa-chevron-up{{#if extra.system.collapsed}} fatex-actions__icon--reverse{{/if}}" data-item="{{extra._id}}"></i>

--- a/system/templates/actor/tabs/stunts.hbs
+++ b/system/templates/actor/tabs/stunts.hbs
@@ -21,6 +21,7 @@
 
                     <div class="fatex-actions fatex-actions--headline">
                         <i class="fatex-js-item-sort fatex-actions__icon fa fa-sort"></i>
+                        <i class="fatex-js-item-to-chat fatex-actions__icon fatex-actions__icon--no-hide fa fa-comment" data-item="{{stunt._id}}"></i>
                         <i class="fatex-js-stunt-settings fatex-actions__icon fa fa-cog" data-item="{{stunt._id}}"></i>
                         <i class="fatex-js-stunt-delete fatex-actions__icon fatex-u-delete fa fa-trash" data-item="{{stunt._id}}"></i>
                         <i class="fatex-js-item-collapse fatex-actions__icon fatex-actions__icon--no-hide fa fa-chevron-up{{#if stunt.system.collapsed}} fatex-actions__icon--reverse{{/if}}" data-item="{{stunt._id}}"></i>

--- a/system/templates/chat/item-card.hbs
+++ b/system/templates/chat/item-card.hbs
@@ -1,5 +1,5 @@
 <div class="fatex-sheet fatex-item-card">
-    <header class="fatex-headline">
+    <header class="fatex-headline fatex-headline--chat">
         <h3 class="fatex-headline__text">{{item.name}}</h3>
     </header>
     <div class="fatex-item-card__content">

--- a/system/templates/chat/item-card.hbs
+++ b/system/templates/chat/item-card.hbs
@@ -1,0 +1,10 @@
+<div class="fatex-sheet fatex-item-card">
+    <header class="fatex-headline">
+        <h3 class="fatex-headline__text">{{item.name}}</h3>
+    </header>
+    <div class="fatex-item-card__content">
+        <div class="fatex-item-card__description">
+            {{{item.system.enrichedDescription}}}
+        </div>
+    </div>
+</div>

--- a/system/templates/components/aspects.hbs
+++ b/system/templates/components/aspects.hbs
@@ -13,6 +13,7 @@
 
             <div class="fatex-actions fatex-actions--item">
                 <i class="fatex-js-item-sort fatex-actions__icon fa fa-sort"></i>
+                <i class="fatex-js-item-to-chat fatex-actions__icon fatex-actions__icon--no-hide fa fa-comment" data-item="{{aspect._id}}"></i>
                 <i class="fatex-js-aspect-settings fatex-actions__icon fa fa-cog" data-item="{{aspect._id}}"></i>
                 <i
                     class="fatex-js-aspect-delete fatex-actions__icon fatex-u-delete fa fa-trash"


### PR DESCRIPTION
linked to this [enhancement issue](https://github.com/anvil-vtt/FateX/issues/133).

- Add a button to display aspects (text and label), stunts (stunt title and description, but not the short description) and extras (extra title and description, but not the short description) to the chat
- Refactor a little to remove TextEditor and renderTemplate deprecation warnings

You can see the visual result in the issue.

The title can be hard to see because it is dark on a dark background. This is because it is already the case in the other chat cards of the system and I want to stay coherent.